### PR TITLE
Fix loading video frames for vp_test from mp4

### DIFF
--- a/slotformer/base_slots/datasets/clevrer.py
+++ b/slotformer/base_slots/datasets/clevrer.py
@@ -77,21 +77,19 @@ class CLEVRERDataset(Dataset):
                 cap.get_frame(start_idx + n * self.frame_offset)
                 for n in range(self.n_sample_frames)
             ]
-            # raise error if any frame is corrupted
-            if any(frame is None for frame in frames):
+        else:
+            # otherwise, read from saved video frames
+            # wrong video length
+            if len(os.listdir(frame_dir)) != self.video_len:
                 raise ValueError
-            return frames
-        # otherwise, read from saved video frames
-        # wrong video length
-        if len(os.listdir(frame_dir)) != self.video_len:
-            raise ValueError
-        # read from jpg images
-        frames = [
-            read_img(
-                os.path.join(frame_dir,
-                             f'{start_idx + n * self.frame_offset:06d}.jpg'))
-            for n in range(self.n_sample_frames)
-        ]
+            # read from jpg images
+            frames = [
+                read_img(
+                    os.path.join(frame_dir,
+                                f'{start_idx + n * self.frame_offset:06d}.jpg'))
+                for n in range(self.n_sample_frames)
+            ]
+        # raise error if any frame is corrupted
         if any(frame is None for frame in frames):
             raise ValueError
         frames = [


### PR DESCRIPTION
When running vp_test with the clevrer config, in case video frames have to be extracted directly form the video, frames are returned as list of numpy images. Instead, a torch tensor of the form [T, 3, H, W] is expected.
This PR fixes the issue by treating the frames the same way as if they were loaded from jpg images instead of returning prematurely.