### PR TITLE
FIX union calculation in hungarian_miou

### DIFF
--- a/slotformer/video_prediction/vp_utils.py
+++ b/slotformer/video_prediction/vp_utils.py
@@ -229,7 +229,7 @@ def hungarian_miou(gt_mask, pred_mask):
     N, M = true_oh.shape[-1], pred_oh.shape[-1]
     # compute all pairwise IoU
     intersect = (true_oh[:, :, None] * pred_oh[:, None, :]).sum(0)  # [N, M]
-    union = true_oh.sum(0)[:, None] + pred_oh.sum(0)[None, :]  # [N, M]
+    union = (true_oh.sum(0)[:, None] + pred_oh.sum(0)[None, :]) - intersect  # [N, M]
     iou = intersect / (union + 1e-8)  # [N, M]
     iou = iou.detach().cpu().numpy()
     # find the best match for each gt


### PR DESCRIPTION
Hey there, we found a small bug in the calculation of the union in the hungarian_miou method. 

Your code uses addition instead of sum and logical_or which results in an upper bound of 0.5 for perfect predictions. For instance, if true_oh == pred_oh, the intersections are simply the sizes of the instances and so should the unions be as well. With the addition however, you count the instance sizes twice which results in the upper bound of 0.5 in this case. An easy fix is to subtract the intersection from this calculation.

Importantly, this bug is most likely only a scaling issue and should not change published results beyond this point.

Best, Johannes